### PR TITLE
Fixups and a surprising build fix

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -101,7 +101,7 @@ static void r_context_configure(void) {
 
 		vars = g_hash_table_new(g_str_hash, g_str_equal);
 
-		g_print("Getting Systeminfo: %s\n", context->config->systeminfo_handler);
+		g_message("Getting Systeminfo: %s\n", context->config->systeminfo_handler);
 		res = launch_and_wait_variables_handler(context->config->systeminfo_handler, vars, &ierror);
 		if (!res) {
 			g_error("Failed to read system-info variables%s", ierror->message);

--- a/src/service.c
+++ b/src/service.c
@@ -142,7 +142,11 @@ out:
 	g_clear_pointer(&manifestpath, g_free);
 
 	if (res) {
-		r_installer_complete_info(interface, invocation, manifest->update_compatible, manifest->update_version);
+		r_installer_complete_info(
+				interface,
+				invocation,
+				manifest->update_compatible,
+				manifest->update_version ? manifest->update_version : "");
 	} else {
 		g_dbus_method_invocation_return_error(invocation,
 						      G_IO_ERROR,

--- a/src/service.c
+++ b/src/service.c
@@ -130,9 +130,6 @@ static gboolean r_on_handle_info(RInstaller *interface,
 		goto out;
 	}
 
-	g_print("compatible: %s\n", manifest->update_compatible);
-	g_print("version:    %s\n", manifest->update_version);
-
 out:
 	if (tmpdir)
 		rm_tree(tmpdir, NULL);


### PR DESCRIPTION
Replacing a direct g_print() by g_message() fixes a SIGPIPE occuring during travis-ci test. Using g_print  here is not recommended, anyway, but I have no real idea why it leads to this error...